### PR TITLE
fix the addon installation script

### DIFF
--- a/minishift/cloud-native-labs.addon
+++ b/minishift/cloud-native-labs.addon
@@ -3,9 +3,9 @@
 #  Parameters that will use:
 #  OPENSHIFT_CONSOLE_URL=#{ip}:8443
 #  COOLSTORE_PROJECT=coolstore
-#  INVENTORY_ROUTE_HOST=inventory-coolstore.#{routting-suffix}
-#  CATALOG_ROUTE_HOST=catalog-coolstore.#{routting-suffix}
-#  API-GATEWAY-ROUTE-HOST=gateway-coolstore.#{routting-suffix}
+#  INVENTORY_ROUTE_HOST=inventory-coolstore.#{routing-suffix}
+#  CATALOG_ROUTE_HOST=catalog-coolstore.#{routing-suffix}
+#  API-GATEWAY-ROUTE-HOST=gateway-coolstore.#{routing-suffix}
 # Url: https://github.com/openshift-roadshow/cloud-native-guides
 
 echo Installing this addon will take some time as it will pull down docker images
@@ -15,10 +15,10 @@ docker pull centos/nodejs-6-centos7
 docker pull redhat-openjdk-18/openjdk18-openshift:latest
 
 
-echo Images have already been pulled. Now let's intall the guide
+echo Images have already been pulled. Now let's install the guide
 
 oc adm new-project cloud-native-labs
-oc new-app osevg/workshopper -e CONTENT_URL_PREFIX=https://raw.githubusercontent.com/simamaksade/cloud-native-guides/master -e WORKSHOPS_URLS=https://raw.githubusercontent.com/openshift-roadshow/cloud-native-guides/master/_cloud-native-roadshow.yml -e OPENSHIFT_CONSOLE_URL=#{ip}:8443 -e COOLSTORE_PROJECT=coolstore -e INVENTORY_ROUTE_HOST=inventory-coolstore.#{routting-suffix} -e CATALOG_ROUTE_HOST=catalog-coolstore.#{routting-suffix} -e API-GATEWAY-ROUTE-HOST=gateway-coolstore.#{routting-suffix} -e ROUTER_ADDRESS=#{routing-suffix} -e USER_NAME=developer -e USER_PASSWORD=developer --name guides -n cloud-native-labs
+oc new-app osevg/workshopper -e CONTENT_URL_PREFIX=https://raw.githubusercontent.com/simamaksade/cloud-native-guides/master -e WORKSHOPS_URLS=https://raw.githubusercontent.com/openshift-roadshow/cloud-native-guides/master/_cloud-native-roadshow.yml -e OPENSHIFT_CONSOLE_URL=#{ip}:8443 -e COOLSTORE_PROJECT=coolstore -e INVENTORY_ROUTE_HOST=inventory-coolstore.#{routing-suffix} -e CATALOG_ROUTE_HOST=catalog-coolstore.#{routing-suffix} -e API_GATEWAY_ROUTE_HOST=gateway-coolstore.#{routing-suffix} -e ROUTER_ADDRESS=#{routing-suffix} -e USER_NAME=developer -e USER_PASSWORD=developer --name guides -n cloud-native-labs
 # Cancel is required as I want to add a probe
 sleep 2
 oc rollout cancel dc/guides -n cloud-native-labs


### PR DESCRIPTION
NOTE This fix still results in a broken workshopper. The guides pod fails to start with this log output: 

* Version 3.10.0 (ruby 2.4.1-p111), codename: Russell's Teapot
* Min threads: 0, max threads: 16
* Environment: development
NoMethodError: undefined method `keys' for nil:NilClass
  /workshopper/lib/workshopper/workshop.rb:62:in `resolve'
  /workshopper/lib/workshopper/workshop.rb:53:in `setup'
  /workshopper/lib/workshopper/workshop.rb:12:in `initialize'
  /workshopper/lib/workshopper/deployment.rb:25:in `new'
  /workshopper/lib/workshopper/deployment.rb:25:in `add'
  /workshopper/lib/workshopper/deployment.rb:11:in `block in initialize'
  /workshopper/lib/workshopper/deployment.rb:10:in `each'
  /workshopper/lib/workshopper/deployment.rb:10:in `initialize'
  /workshopper/lib/workshopper/webapp.rb:10:in `new'
  /workshopper/lib/workshopper/webapp.rb:10:in `<class:Webapp>'
  /workshopper/lib/workshopper/webapp.rb:5:in `<module:Workshopper>'
  /workshopper/lib/workshopper/webapp.rb:4:in `<top (required)>'
  /workshopper/lib/workshopper.rb:13:in `require'
  /workshopper/lib/workshopper.rb:13:in `<top (required)>'
  config.ru:3:in `require'
  config.ru:3:in `block in <main>'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/builder.rb:55:in `instance_eval'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/builder.rb:55:in `initialize'
  config.ru:in `new'
  config.ru:in `<main>'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/builder.rb:49:in `eval'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/builder.rb:49:in `new_from_string'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/builder.rb:40:in `parse_file'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/configuration.rb:314:in `load_rackup'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/configuration.rb:243:in `app'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/runner.rb:138:in `load_and_bind'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/single.rb:87:in `run'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/launcher.rb:183:in `run'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/cli.rb:77:in `run'
  /workshopper/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/bin/puma:10:in `<top (required)>'
  /workshopper/vendor/bundle/ruby/2.4.0/bin/puma:22:in `load'
  /workshopper/vendor/bundle/ruby/2.4.0/bin/puma:22:in `<top (required)>'
! Unable to load application: NoMethodError: undefined method `keys' for nil:NilClass
bundler: failed to load command: puma (/workshopper/vendor/bundle/ruby/2.4.0/bin/puma)